### PR TITLE
Fix #8, add animal blacklist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ dependencies {
     implementation fg.deobf("curse.maven:jei-238222:4609866")
     implementation fg.deobf("curse.maven:patchouli-306770:4636277")
     implementation fg.deobf("curse.maven:jade-324717:4654448")
-    implementation fg.deobf("curse.maven:terrafirmacraft-302973:5276689")
+    implementation fg.deobf("curse.maven:terrafirmacraft-302973:6835820")
     implementation fg.deobf("curse.maven:arborfirmacraft-877545:5242050")
 }
 

--- a/src/main/java/cy/jdkdigital/tfcgroomer/common/block/entity/GroomingStationBlockEntity.java
+++ b/src/main/java/cy/jdkdigital/tfcgroomer/common/block/entity/GroomingStationBlockEntity.java
@@ -125,6 +125,8 @@ public class GroomingStationBlockEntity extends TickableInventoryBlockEntity<Gro
                                 itemStack);
                     }
 
+                    be.inventory.onContentsChanged(currentStacks.indexOf(itemStack));
+
                     Groomer.LOGGER.debug("itemStack: {} | INIT stack count: {} | FINAL stack count: {}",
                             itemStack.getHoverName().getString(),
                             initCount,

--- a/src/main/java/cy/jdkdigital/tfcgroomer/common/block/entity/GroomingStationBlockEntity.java
+++ b/src/main/java/cy/jdkdigital/tfcgroomer/common/block/entity/GroomingStationBlockEntity.java
@@ -33,11 +33,14 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraftforge.common.util.FakePlayerFactory;
 import net.minecraftforge.common.util.INBTSerializable;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -80,8 +83,14 @@ public class GroomingStationBlockEntity extends TickableInventoryBlockEntity<Gro
             boolean isChild = tfcAnimal.getAgeType() == TFCAnimalProperties.Age.CHILD;
             boolean animalHungry = tfcAnimal.isHungry();
 
+            assert Arrays.stream(tfcAnimal.getClass().getMethods())
+                    .map(Method::getName)
+                    .anyMatch(n -> n.equals("isFood"))
+                    : String.format("animal does not have isFood(). animal dump: \n" + ReflectionToStringBuilder.toString(tfcAnimal));
+
             for (ItemStack stack : currentStacks) {
                 boolean stackHasItems = !stack.isEmpty();
+
                 boolean stackIsEdible = tfcAnimal.isFood(stack);
                 // Feeding logic
                 if (stackHasItems && animalHungry && stackIsEdible) {

--- a/src/main/java/cy/jdkdigital/tfcgroomer/common/block/entity/GroomingStationBlockEntity.java
+++ b/src/main/java/cy/jdkdigital/tfcgroomer/common/block/entity/GroomingStationBlockEntity.java
@@ -10,7 +10,7 @@ import net.dries007.tfc.common.blockentities.TickableInventoryBlockEntity;
 import net.dries007.tfc.common.capabilities.InventoryItemHandler;
 import net.dries007.tfc.common.capabilities.PartialItemHandler;
 import net.dries007.tfc.common.capabilities.food.FoodCapability;
-import net.dries007.tfc.common.capabilities.size.ItemSizeManager;
+import net.dries007.tfc.common.entities.livestock.TFCAnimal;
 import net.dries007.tfc.common.entities.livestock.TFCAnimalProperties;
 import net.dries007.tfc.util.IntArrayBuilder;
 import net.minecraft.core.BlockPos;
@@ -20,34 +20,35 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.TagKey;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerData;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraftforge.common.util.FakePlayerFactory;
 import net.minecraftforge.common.util.INBTSerializable;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
 
 public class GroomingStationBlockEntity extends TickableInventoryBlockEntity<GroomingStationBlockEntity.GroomingStationInventory>
 {
-    private static final Component NAME = Component.translatable("block.tfcgroomer.grooming_station"); // TODO: add localization
+    private static final Component NAME = Component.translatable("block.tfcgroomer.grooming_station");
     static final UUID PLAYER_UUID = UUID.nameUUIDFromBytes("grooming_station".getBytes(StandardCharsets.UTF_8));
     private double range = 1;
     int counter;
@@ -56,7 +57,11 @@ public class GroomingStationBlockEntity extends TickableInventoryBlockEntity<Gro
         if (groomStation.counter-- > 0 || !(level instanceof ServerLevel)) return;
         groomStation.counter = GroomerConfig.SERVER.groomingStationTicks.get();
 
-        // Inventory updates
+        // check for valid animals
+        List<Animal> entities = level.getEntitiesOfClass(Animal.class, (new AABB(pos).inflate(groomStation.range, 1d, groomStation.range)));
+        if (entities.isEmpty()) return;
+
+        // if animals then check inventory
         List<ItemStack> stacks = new ArrayList<>();
         for (int i = 0; i < groomStation.inventory.getSlots(); i++) {
             var stack = groomStation.inventory.getStackInSlot(i);
@@ -65,45 +70,69 @@ public class GroomingStationBlockEntity extends TickableInventoryBlockEntity<Gro
             }
         }
 
+        if (stacks.isEmpty()) return;
+
         // Animal feeding
-        List<Animal> entities = level.getEntitiesOfClass(Animal.class, (new AABB(pos).inflate(groomStation.range, 1d, groomStation.range))).stream().toList();
-        if (entities.isEmpty()) return;
-
         Player fakePlayer = FakePlayerFactory.get((ServerLevel) level, new GameProfile(PLAYER_UUID, "grooming_station"));
-
-        entities.forEach(animal -> feedAnimalIfConditionsMet(animal, stacks, fakePlayer, groomStation.breedingEnabled));
-
-
+        entities.forEach(animal -> feedAnimalIfConditionsMet(groomStation, animal, stacks, fakePlayer, groomStation.breedingEnabled));
     }
 
-    private static void feedAnimalIfConditionsMet(Animal animal, List<ItemStack> currentStacks, Player fakePlayer, boolean breedingEnabled) {
-        if (animal instanceof TFCAnimalProperties tfcAnimal) {
+    /**
+     * Feeds an animal via fakePlayer proxy, avoiding {@link <a href="https://github.com/TerraFirmaCraft/TerraFirmaCraft/issues/2862">TFC Issue 2862</a>}
+     * @param be grooming station block entity
+     * @param animal animal to be fed
+     * @param currentStacks provided food itemStacks
+     * @param fakePlayer fakePlayer attached to grooming station block entity
+     * @param breedingEnabled whether feeding at max familiarity is enabled
+     */
+    private static void feedAnimalIfConditionsMet(GroomingStationBlockEntity be, Animal animal, List<ItemStack> currentStacks, Player fakePlayer, boolean breedingEnabled) {
+        if (animal instanceof TFCAnimal tfcAnimal) {
+            boolean animalHungry = tfcAnimal.isHungry();
+            if (!animalHungry) return;
 
+            if (GroomerConfig.SERVER.animalBlacklist.get().contains(EntityType.getKey(animal.getType()).toString())) {
+                Groomer.LOGGER.info("{} on blacklist, ignoring", animal.getType());
+                return;
+            }
+
+            // 1. query animal for food tags
+            TagKey<Item> foodTag = tfcAnimal.getFoodTag();
+
+            // 2. check for feeding preconditions
             float animalFamiliarity = tfcAnimal.getFamiliarity();
             boolean isChild = tfcAnimal.getAgeType() == TFCAnimalProperties.Age.CHILD;
-            boolean animalHungry = tfcAnimal.isHungry();
+            boolean childCanGrow = isChild && animalFamiliarity < 1.0f;
+            boolean adultCanFamiliarize = animalFamiliarity < tfcAnimal.getAdultFamiliarityCap();
 
-            assert Arrays.stream(tfcAnimal.getClass().getMethods())
-                    .map(Method::getName)
-                    .anyMatch(n -> n.equals("isFood"))
-                    : String.format("animal does not have isFood(). animal dump: \n" + ReflectionToStringBuilder.toString(tfcAnimal));
+            // 3. iterate through usable food items
+            for (ItemStack itemStack : currentStacks) {
+                if (!itemStack.is(foodTag) || itemStack.isEmpty()) return;
+                if (!tfcAnimal.eatsRottenFood() && FoodCapability.isRotten(itemStack)) return;
 
-            for (ItemStack stack : currentStacks) {
-                boolean stackHasItems = !stack.isEmpty();
+                if (breedingEnabled || childCanGrow || adultCanFamiliarize) {
+                    int initCount = itemStack.getCount();
+                    // use fakePlayer as proxy to feed animal, avoiding interacting with any shadowed animal methods
+                    fakePlayer.setItemInHand(InteractionHand.MAIN_HAND, itemStack.split(1));
+                    InteractionResult res = fakePlayer.interactOn(tfcAnimal, InteractionHand.MAIN_HAND);
 
-                boolean stackIsEdible = tfcAnimal.isFood(stack);
-                // Feeding logic
-                if (stackHasItems && animalHungry && stackIsEdible) {
-                    if (breedingEnabled) {
-                        tfcAnimal.eatFood(stack, InteractionHand.MAIN_HAND, fakePlayer);
-                        break;
-                    } else {
-                        if ((isChild && animalFamiliarity < 1.0f) || (animalFamiliarity < tfcAnimal.getAdultFamiliarityCap())) {
-                            tfcAnimal.eatFood(stack, InteractionHand.MAIN_HAND, fakePlayer);
-                            break;
-                        }
+                    // if for some reason the feeding failed or the proxy has residual items, clear proxy inventory and restore itemstack to initial state
+                    if (res.equals(InteractionResult.FAIL) || !fakePlayer.getItemInHand(InteractionHand.MAIN_HAND).isEmpty()) {
+                        itemStack.setCount(initCount);
+                        fakePlayer.getInventory().clearContent();
+                        Groomer.LOGGER.warn("Grooming station ({}) tried to feed {} with {} but failed! Returning food to grooming station and clearing proxy inventory.",
+                                be.getBlockPos(),
+                                tfcAnimal.getTypeName().getString(),
+                                itemStack);
                     }
+
+                    Groomer.LOGGER.debug("itemStack: {} | INIT stack count: {} | FINAL stack count: {}",
+                            itemStack.getHoverName().getString(),
+                            initCount,
+                            itemStack.getCount());
                 }
+
+                // if animal was successfully fed then exit loop
+                if (!tfcAnimal.isHungry()) break;
             }
         }
     }
@@ -189,7 +218,7 @@ public class GroomingStationBlockEntity extends TickableInventoryBlockEntity<Gro
                     itemCount += stack.getCount();
                 }
             }
-            int level = itemCount >= 160 ? 2 : (itemCount > 0 ? 1 : 0);
+            int level = ((GroomingStationBlockEntity) this.entity).getAnalogOutputSignal() >= 8 ? 2 : (itemCount > 0 ? 1 : 0);
             if (this.entity.getBlockState().hasProperty(GroomingStation.LEVEL) && this.entity.getLevel() instanceof ServerLevel serverLevel) {
                 var currentLevel = this.entity.getBlockState().getValue(GroomingStation.LEVEL);
                 if (currentLevel != level) {

--- a/src/main/java/cy/jdkdigital/tfcgroomer/config/ServerConfig.java
+++ b/src/main/java/cy/jdkdigital/tfcgroomer/config/ServerConfig.java
@@ -1,9 +1,11 @@
 package cy.jdkdigital.tfcgroomer.config;
 
  import net.dries007.tfc.util.Metal;
-import net.minecraftforge.common.ForgeConfigSpec;
+ import net.minecraft.world.entity.EntityType;
+ import net.minecraftforge.common.ForgeConfigSpec;
 
-import java.util.EnumMap;
+ import java.util.EnumMap;
+ import java.util.List;
 
 public class ServerConfig {
 
@@ -21,6 +23,7 @@ public class ServerConfig {
     public final ForgeConfigSpec.BooleanValue groomingStationRedstoneOutput;
 
     // TODO: Animal blacklist
+    public final ForgeConfigSpec.ConfigValue<List<? extends String>> animalBlacklist;
 
 
     ServerConfig(ConfigBuilderWrapper builder) {
@@ -43,9 +46,12 @@ public class ServerConfig {
             }
         }
 
-        builder.swap("whitelist");
+        builder.swap("blacklist");
 
         // TODO: Animal Blacklist
+        animalBlacklist = builder
+                .comment("Animals ignored by the grooming station when feeding. Parsed as a resource location. For example: 'tfc:duck'")
+                .define("animalBlacklist", List.of(), entry -> EntityType.byString(entry).isPresent());
 
         builder.swap("automation");
 

--- a/src/main/java/cy/jdkdigital/tfcgroomer/config/ServerConfig.java
+++ b/src/main/java/cy/jdkdigital/tfcgroomer/config/ServerConfig.java
@@ -22,7 +22,6 @@ public class ServerConfig {
     public final ForgeConfigSpec.BooleanValue groomingStationEnableAutomation;
     public final ForgeConfigSpec.BooleanValue groomingStationRedstoneOutput;
 
-    // TODO: Animal blacklist
     public final ForgeConfigSpec.ConfigValue<List<? extends String>> animalBlacklist;
 
 
@@ -46,18 +45,18 @@ public class ServerConfig {
             }
         }
 
+        builder.swap("automation");
+
+        groomingStationEnableAutomation = builder.comment("If true, grooming stations will interact with in-world automation such as hoppers on a side-specific basis.").define("groomingStationEnableAutomation", true);
+
+        groomingStationRedstoneOutput = builder.comment("If true, the Grooming Station will emit a redstone signal proportional to how full it is.").define("groomingStationRedstoneOutput", true);
+
         builder.swap("blacklist");
 
         // TODO: Animal Blacklist
         animalBlacklist = builder
                 .comment("Animals ignored by the grooming station when feeding. Parsed as a resource location. For example: 'tfc:duck'")
                 .define("animalBlacklist", List.of(), entry -> EntityType.byString(entry).isPresent());
-
-        builder.swap("automation");
-
-        groomingStationEnableAutomation = builder.comment("If true, grooming stations will interact with in-world automation such as hoppers on a side-specific basis.").define("groomingStationEnableAutomation", true);
-
-        groomingStationRedstoneOutput = builder.comment("If true, the Grooming Station will emit a redstone signal proportional to how full it is.").define("groomingStationRedstoneOutput", true);
 
         builder.pop();
     }


### PR DESCRIPTION
Animal feeding is now done through a fake player proxy to avoid querying tfcAnimal#isFood(), with additional debug messaging and warnings in the case of a failure. In a nutshell, things should fail gracefully now and not crash people's games. The grooming station will simply fail to feed an animal if a problem occurs during the feeding process.
Also added an animal blacklist.