### PR TITLE
Fix Item Duplication

### DIFF
--- a/src/main/java/cy/jdkdigital/tfcgroomer/inventory/GroomingStationContainer.java
+++ b/src/main/java/cy/jdkdigital/tfcgroomer/inventory/GroomingStationContainer.java
@@ -31,7 +31,7 @@ public class GroomingStationContainer extends BlockEntityContainer<GroomingStati
     @Override
     protected boolean moveStack(@NotNull ItemStack stack, int slotIndex) {
         return switch (this.typeOf(slotIndex)) {
-            case MAIN_INVENTORY, HOTBAR -> !this.moveItemStackTo(stack, 0, 9, false);
+            case MAIN_INVENTORY, HOTBAR -> !this.moveItemStackTo(stack, 0, 4, false);
             case CONTAINER -> !this.moveItemStackTo(stack, this.containerSlots, this.slots.size(), false);
         };
     }


### PR DESCRIPTION
Only 4 slots are registered which led to items being pushed back to player inventory as they were being moved and other weird behaviors.

Fixes https://github.com/JDKDigital/tfcgroomer/issues/14